### PR TITLE
Fix CI failures for new pages (SOFTWARE-4343)

### DIFF
--- a/.github/workflows/validate-mkdocs.yml
+++ b/.github/workflows/validate-mkdocs.yml
@@ -14,6 +14,10 @@ jobs:
             build
             --verbose
             --strict
+
+      - id: format-github-repo
+        run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY#*\/}"
+
       - name: Test links
         timeout-minutes: 10
         uses: docker://klakegg/html-proofer:3.16.0
@@ -23,5 +27,5 @@ jobs:
             --check-html
             --http-status-ignore 302
             --file-ignore ./site/404.html
-            --url-ignore "https://fonts.gstatic.com,/github.com\/opensciencegrid\/${GITHUB_REPOSITORY#*\/}\/edit/,/opensciencegrid.org\/${GITHUB_REPOSITORY#*\/}/"
+            --url-ignore "https://fonts.gstatic.com,/github.com\/opensciencegrid\/${{ steps.format-github-repo.outputs.repo-name }}\/edit/,/opensciencegrid.org\/${{ steps.format-github-repo.outputs.repo-name }}/"
             ./site


### PR DESCRIPTION
1.  MkDocs generates new pages with full links to edit the doc in
GitHub and to itself somewhere
2.  Linkchecker dutifully checks that these links return reasonable
HTTP codes, which they won't because they haven't been published yet
in a PR scenario
